### PR TITLE
Make event fields optional

### DIFF
--- a/jekyll_files/admin/config.yml
+++ b/jekyll_files/admin/config.yml
@@ -13,11 +13,11 @@ collections:
   slug: "{{year}}-{{slug}}"
   fields:
     - { label: "Title", name: "title", widget: "string" }
-    - { label: "Header image", name: "header_image", widget: "image" }
-    - { label: "Start time", name: "start_time", widget: "datetime" }
-    - { label: "Location", name: "location", widget: "string" }
-    - { label: "Register URL", name: "register_url", widget: "text" }
-    - { label: "Button text", name: "button_text", widget: "string" }
+    - { label: "Header image", name: "header_image", widget: "image", required: false }
+    - { label: "Start time", name: "start_time", widget: "datetime", required: false }
+    - { label: "Location", name: "location", widget: "string", required: false }
+    - { label: "Register URL", name: "register_url", widget: "text", required: false }
+    - { label: "Button text", name: "button_text", widget: "string", required: false }
     - { label: "Body", name: "body", widget: "markdown" }
 - name: "page"
   label: "Page"


### PR DESCRIPTION
Fields in Decap CMS are required by default. Most of the fields are not needed for an event. Therefore they are now optional.